### PR TITLE
Replace commented out methods with comments

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -15,7 +15,7 @@ class Comment < ApplicationRecord
   
   ## Direct associations
 
-  # Comment#author: returns a row from the users table associated to this like by the author_id column
+  # Comment#commenter: returns a row from the users table associated to this comment by the author_id column
 
-  # Comment#photo: returns a row from the photos table associated to this like by the photo_id column
+  # Comment#photo: returns a row from the photos table associated to this comment by the photo_id column
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -11,25 +11,11 @@
 #
 
 class Comment < ApplicationRecord
-  # validates(:commenter, { :presence => true })
+  # Association accessor methods to define:
+  
+  ## Direct associations
 
-  # def commenter
-  #   my_author_id = self.author_id
+  # Comment#author: returns a row from the users table associated to this like by the author_id column
 
-  #   matching_users = User.where({ :id => my_author_id })
-
-  #   the_user = matching_users.at(0)
-
-  #   return the_user
-  # end
-
-  # def photo
-  #   my_photo_id = self.photo_id
-
-  #   matching_photos = User.where({ :id => my_photo_id })
-
-  #   the_photo = matching_photos.at(0)
-
-  #   return the_photo
-  # end
+  # Comment#photo: returns a row from the photos table associated to this like by the photo_id column
 end

--- a/app/models/follow_request.rb
+++ b/app/models/follow_request.rb
@@ -11,29 +11,11 @@
 #
 
 class FollowRequest < ApplicationRecord
-  # validates(:sender, { :presence => true})
-  # validates(:recipient, {
-  #   :presence => true,
-  #   :uniqueness => { :scope => [:sender_id] }
-  # })
+  # Association accessor methods to define:
+  
+  ## Direct associations
 
-  # def sender
-  #   my_sender_id = self.sender_id
+  # FollowRequest#sender: returns a row from the users table associated to this follow request by the sender_id column
 
-  #   matching_users = User.where({ :id => my_sender_id })
-
-  #   the_user = matching_users.at(0)
-
-  #   return the_user
-  # end
-
-  # def recipient
-  #   my_recipient_id = self.recipient_id
-
-  #   matching_users = User.where({ :id => my_recipient_id })
-
-  #   the_user = matching_users.at(0)
-
-  #   return the_user
-  # end
+  # FollowRequest#recipient: returns a row from the users table associated to this follow request by the recipient_id column
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -16,5 +16,5 @@ class Like < ApplicationRecord
 
   # Like#fan: returns a row from the users table associated to this like by the fan_id column
 
-  # Like#photo: returns a row from the users table associated to this like by the fan_id column
+  # Like#photo: returns a row from the photo table associated to this like by the photo_id column
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -10,29 +10,11 @@
 #
 
 class Like < ApplicationRecord
-  # validates(:fan, { :presence => true })
-  # validates(:photo, { 
-  #   :presence => true,
-  #   :uniqueness => { :scope => [:fan_id] }
-  # })
+  # Association accessor methods to define:
+  
+  ## Direct associations
 
-  # def fan
-  #   my_fan_id = self.fan_id
+  # Like#fan: returns a row from the users table associated to this like by the fan_id column
 
-  #   matching_users = User.where({ :id => my_fan_id })
-
-  #   the_user = matching_users.at(0)
-
-  #   return the_user
-  # end
-
-  # def photo
-  #   my_photo_id = self.photo_id
-
-  #   matching_photos = Photo.where({ :id => my_photo_id })
-
-  #   the_photo = matching_photos.at(0)
-
-  #   return the_photo
-  # end
+  # Like#photo: returns a row from the users table associated to this like by the fan_id column
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -13,59 +13,17 @@
 #
 
 class Photo < ApplicationRecord
-  # validates(:poster, { :presence => true })
+  # Association accessor methods to define:
+  
+  ## Direct associations
 
-  # def poster
-  #   my_owner_id = self.owner_id
+  # Photo#poster: returns a row from the users table associated to this photo by the owner_id column
+  
+  # Photo#comments: returns rows from the comments table associated to this photo by the photo_id column
 
-  #   matching_users = User.where({ :id => my_owner_id })
+  # Photo#likes: returns rows from the likes table associated to this photo by the photo_id column
 
-  #   the_user = matching_users.at(0)
+  ## Indirect associations
 
-  #   return the_user
-  # end
-
-  # def comments
-  #   my_id = self.id
-
-  #   matching_comments = Comment.where({ :photo_id => self.id })
-
-  #   return matching_comments
-  # end
-
-  # def likes
-  #   my_id = self.id
-
-  #   matching_likes = Like.where({ :photo_id => self.id })
-
-  #   return matching_likes
-  # end
-
-  # def fans
-  #   my_likes = self.likes
-    
-  #   array_of_user_ids = Array.new
-
-  #   my_likes.each do |a_like|
-  #     array_of_user_ids.push(a_like.fan_id)
-  #   end
-
-  #   matching_users = User.where({ :id => array_of_user_ids })
-
-  #   return matching_users
-  # end
-
-  # def fan_list
-  #   my_fans = self.fans
-
-  #   array_of_usernames = Array.new
-
-  #   my_fans.each do |a_user|
-  #     array_of_usernames.push(a_user.username)
-  #   end
-
-  #   formatted_usernames = array_of_usernames.to_sentence
-
-  #   return formatted_usernames
-  # end
+  # Photo#fans: returns rows from the users table associated to this photo through its likes
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,158 +12,33 @@
 #
 
 class User < ApplicationRecord
-  # validates(:username, {
-  #   :presence => true,
-  #   :uniqueness => { :case_sensitive => false },
-  # })
+  validates(:username, {
+    :presence => true,
+    :uniqueness => { :case_sensitive => false },
+  })
 
-  # def comments
-  #   my_id = self.id
+  # Association accessor methods to define:
+  
+  ## Direct associations
 
-  #   matching_comments = Comment.where({ :author_id => my_id })
+  # User#comments: returns rows from the comments table associated to this user by the author_id column
+  # User#own_photos: returns rows from the photos table  associated to this user by the owner_id column
+  # User#likes: returns rows from the likes table associated to this user by the fan_id column
+  # User#sent_follow_requests: returns rows from the follow requests table associated to this user by the sender_id column
+  # User#received_follow_requests: returns rows from the follow requests table associated to this user by the recipient_id column
 
-  #   return matching_comments
-  # end
+  ### Scoped direct associations
 
-  # def own_photos
-  #   my_id = self.id
+  # User#accepted_sent_follow_requests: returns rows from the follow requests table associated to this user by the sender_id column, where status is 'accepted'
+  # User#accepted_received_follow_requests: returns rows from the follow requests table associated to this user by the recipient_id column, where status is 'accepted'
+  
+  ## Indirect associations
 
-  #   matching_photos = Photo.where({ :owner_id => my_id })
+  # User#liked_photos: returns rows from the photos table associated to this user through their likes
+  # User#commented_photos: returns rows from the photos table associated to this user through their comments
 
-  #   return matching_photos
-  # end
-
-  # def likes
-  #   my_id = self.id
-
-  #   matching_likes = Like.where({ :fan_id => my_id })
-
-  #   return matching_likes
-  # end
-
-  # def liked_photos
-  #   my_likes = self.likes
-    
-  #   array_of_photo_ids = Array.new
-
-  #   my_likes.each do |a_like|
-  #     array_of_photo_ids.push(a_like.photo_id)
-  #   end
-
-  #   matching_photos = Photo.where({ :id => array_of_photo_ids })
-
-  #   return matching_photos
-  # end
-
-  # def commented_photos
-  #   my_comments = self.comments
-    
-  #   array_of_photo_ids = Array.new
-
-  #   my_comments.each do |a_comment|
-  #     array_of_photo_ids.push(a_comment.photo_id)
-  #   end
-
-  #   matching_photos = Photo.where({ :id => array_of_photo_ids })
-
-  #   unique_matching_photos = matching_photos.distinct
-
-  #   return unique_matching_photos
-  # end
-
-  # def sent_follow_requests
-  #   my_id = self.id
-
-  #   matching_follow_requests = FollowRequest.where({ :sender_id => my_id })
-
-  #   return matching_follow_requests
-  # end
-
-  # def received_follow_requests
-  #   my_id = self.id
-
-  #   matching_follow_requests = FollowRequest.where({ :recipient_id => my_id })
-
-  #   return matching_follow_requests
-  # end
-
-  # def accepted_sent_follow_requests
-  #   my_sent_follow_requests = self.sent_follow_requests
-
-  #   matching_follow_requests = my_sent_follow_requests.where({ :status => "accepted" })
-
-  #   return matching_follow_requests
-  # end
-
-  # def accepted_received_follow_requests
-  #   my_received_follow_requests = self.received_follow_requests
-
-  #   matching_follow_requests = my_received_follow_requests.where({ :status => "accepted" })
-
-  #   return matching_follow_requests
-  # end
-
-  # def followers
-  #   my_accepted_received_follow_requests = self.accepted_received_follow_requests
-    
-  #   array_of_user_ids = Array.new
-
-  #   my_accepted_received_follow_requests.each do |a_follow_request|
-  #     array_of_user_ids.push(a_follow_request.sender_id)
-  #   end
-
-  #   matching_users = User.where({ :id => array_of_user_ids })
-
-  #   return matching_users
-  # end
-
-  # def leaders
-  #   my_accepted_sent_follow_requests = self.accepted_sent_follow_requests
-    
-  #   array_of_user_ids = Array.new
-
-  #   my_accepted_sent_follow_requests.each do |a_follow_request|
-  #     array_of_user_ids.push(a_follow_request.recipient_id)
-  #   end
-
-  #   matching_users = User.where({ :id => array_of_user_ids })
-
-  #   return matching_users
-  # end
-
-  # def feed
-  #   array_of_photo_ids = Array.new
-
-  #   my_leaders = self.leaders
-    
-  #   my_leaders.each do |a_user|
-  #     leader_own_photos = a_user.own_photos
-
-  #     leader_own_photos.each do |a_photo|
-  #       array_of_photo_ids.push(a_photo.id)
-  #     end
-  #   end
-
-  #   matching_photos = Photo.where({ :id => array_of_photo_ids })
-
-  #   return matching_photos
-  # end
-
-  # def discover
-  #   array_of_photo_ids = Array.new
-
-  #   my_leaders = self.leaders
-    
-  #   my_leaders.each do |a_user|
-  #     leader_liked_photos = a_user.liked_photos
-
-  #     leader_liked_photos.each do |a_photo|
-  #       array_of_photo_ids.push(a_photo.id)
-  #     end
-  #   end
-
-  #   matching_photos = Photo.where({ :id => array_of_photo_ids })
-
-  #   return matching_photos
-  # end
+  # User#followers: returns rows from the users table associated to this user through their accepted_received_follow_requests
+  # User#leaders: returns rows from the users table associated to this user through their accepted_sent_follow_requests
+  # User#feed: returns rows from the photos table associated to this user through their leaders (the leaders' own_photos)
+  # User#discover: returns rows from the photos table associated to this user through their leaders (the leaders' liked_photos)
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,23 +22,37 @@ class User < ApplicationRecord
   ## Direct associations
 
   # User#comments: returns rows from the comments table associated to this user by the author_id column
+
   # User#own_photos: returns rows from the photos table  associated to this user by the owner_id column
+
   # User#likes: returns rows from the likes table associated to this user by the fan_id column
+
   # User#sent_follow_requests: returns rows from the follow requests table associated to this user by the sender_id column
+
   # User#received_follow_requests: returns rows from the follow requests table associated to this user by the recipient_id column
+
 
   ### Scoped direct associations
 
   # User#accepted_sent_follow_requests: returns rows from the follow requests table associated to this user by the sender_id column, where status is 'accepted'
+
   # User#accepted_received_follow_requests: returns rows from the follow requests table associated to this user by the recipient_id column, where status is 'accepted'
   
+
   ## Indirect associations
 
-  # User#liked_photos: returns rows from the photos table associated to this user through their likes
-  # User#commented_photos: returns rows from the photos table associated to this user through their comments
+  # User#liked_photos: returns rows from the photos table associated to this user through its likes
 
-  # User#followers: returns rows from the users table associated to this user through their accepted_received_follow_requests
-  # User#leaders: returns rows from the users table associated to this user through their accepted_sent_follow_requests
-  # User#feed: returns rows from the photos table associated to this user through their leaders (the leaders' own_photos)
-  # User#discover: returns rows from the photos table associated to this user through their leaders (the leaders' liked_photos)
+  # User#commented_photos: returns rows from the photos table associated to this user through its comments
+
+
+  ### Indirect associations built on scoped associations
+
+  # User#followers: returns rows from the users table associated to this user through its accepted_received_follow_requests (the follow requests' senders)
+
+  # User#leaders: returns rows from the users table associated to this user through its accepted_sent_follow_requests (the follow requests' recipients)
+
+  # User#feed: returns rows from the photos table associated to this user through its leaders (the leaders' own_photos)
+
+  # User#discover: returns rows from the photos table associated to this user through its leaders (the leaders' liked_photos)
 end


### PR DESCRIPTION
The commented out methods were outdated and sometimes just plain incorrect, and therefore misleading. Given the existence of the association-accessors tool (which will produce up-to-date method code anyway), I thought it best to frame the tasks in terms of using the association-accessors tool. I welcome any thoughts.